### PR TITLE
Fix MEMBERSHIP_LOCATION parameter

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -60,7 +60,7 @@ gcloud container fleet mesh update \
     --management automatic \
     --memberships asm-sample-cluster \
     --project $PROJECT_ID \
-    --location global
+    --location $REGION
 
 # check asm control plane status
 gcloud container fleet mesh describe --project $PROJECT_ID


### PR DESCRIPTION
For clusters created after May 2023, the region must be specified instead of `global`.

see: https://cloud.google.com/service-mesh/docs/managed/provision-managed-anthos-service-mesh?hl=ja